### PR TITLE
use textdomain in ACF exports

### DIFF
--- a/App/Fields/ACF.php
+++ b/App/Fields/ACF.php
@@ -2,12 +2,14 @@
 
 namespace AD\App\Fields;
 
+use AD\App\Interfaces\WordPressHooks;
+
 /**
  * Class ACF
  *
  * @package AD\App\Fields
  */
-class ACF {
+class ACF implements WordPressHooks {
 
     /**
      * ACF constructor.
@@ -15,6 +17,17 @@ class ACF {
     public function __construct() {
         // load ACF Fields
         require_once AD_THEME_DIR . 'inc/acf/fields.php';
+    }
+
+    /**
+     * Add hooks.
+     */
+    public function addHooks() {
+
+        // ACF field PHP exports will wrap text in the ad-starter text domain.
+        add_filter('acf/settings/l10n_textdomain', function() {
+            return 'ad-starter';
+        });
     }
 
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.3.0] - 2018-05-07
+- Wrap ACF PHP field exports in text domain.
+
 ## [2.2.0] - 2018-01-15
 ### Added
 - ACF Pro dependency

--- a/functions.php
+++ b/functions.php
@@ -37,8 +37,9 @@ add_action( 'after_setup_theme', function () {
         ->add( new Options() )
         ->add( new Modules() )
         ->add( new Shortcodes() )
+        ->add( new ACF() )
         ->initialize();
-    new ACF();
+
     new Media();
 
     // Translation setup

--- a/functions.php
+++ b/functions.php
@@ -18,7 +18,7 @@ use AD\App\Shortcodes;
  * Define Theme Version
  * Define Theme directories
  */
-define( 'THEME_VERSION', '2.2.0' );
+define( 'THEME_VERSION', '2.3.0' );
 define( 'AD_THEME_DIR', trailingslashit( get_template_directory() ) );
 define( 'AD_THEME_PATH_URL', trailingslashit( get_template_directory_uri() ) );
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://ackmanndickenson.com
 Author: Ackmann & Dickenson
 Author URI: http://ackmanndickenson.com
 Description: A starter framework for WordPress themes.
-Version: 2.2.0
+Version: 2.3.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: ad-starter


### PR DESCRIPTION
A textdomain will now be automatically added when exporting ACF fields as PHP.